### PR TITLE
fix(repeatable): Add version suffix to repeatable migration description

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ executors:
 
 commands:
   install-jdk:
-    description: Install and setup the JVM environmnet
+    description: Install and setup the JDK environmnet
     parameters:
       version:
         description: The JDK version to use
@@ -30,7 +30,7 @@ commands:
           key: v1-<<parameters.version>>-{{ checksum "~/jdk/<<parameters.version>>.sha256" }}
 
       - run:
-          name: Download JDK 18
+          name: Download JDK
           command: |
             if [ ! -f ~/jdk/<<parameters.version>>.tar.gz ]; then
               wget -nc https://download.oracle.com/java/18/latest/<<parameters.version>>_linux-x64_bin.tar.gz -O ~/jdk/<<parameters.version>>.tar.gz

--- a/src/main/java/io/github/joselion/atomicflyway/AtomicMigration.java
+++ b/src/main/java/io/github/joselion/atomicflyway/AtomicMigration.java
@@ -66,7 +66,13 @@ public interface AtomicMigration extends JavaMigration {
 
   @Override
   default String getDescription() {
-    return this.nameMatcher().group(4);
+    final var className = getClass().getSimpleName();
+    final var repeatableMatcher = REPEATABLE_PATTERN.matcher(className);
+    final var baseDescription = this.nameMatcher().group(4);
+
+    return repeatableMatcher.matches()
+      ? this.nameMatcher().group(2).concat(baseDescription)
+      : baseDescription;
   }
 
   @Override

--- a/src/test/java/io/github/joselion/atomicflyway/AtomicMigrationTest.java
+++ b/src/test/java/io/github/joselion/atomicflyway/AtomicMigrationTest.java
@@ -42,10 +42,20 @@ import io.github.joselion.testing.migrations.V002AddCreatedAtToAccount;
   }
 
   @Nested class getDescription {
-    @Test void returns_the_name_of_the_migrations_without_the_version_prefix() {
-      final var migration = new V001CreateAccountTable();
+    @Nested class when_the_migration_is_not_repeatable {
+      @Test void returns_the_name_of_the_migrations_without_the_version_prefix() {
+        final var migration = new V001CreateAccountTable();
 
-      assertThat(migration.getDescription()).isEqualTo("CreateAccountTable");
+        assertThat(migration.getDescription()).isEqualTo("CreateAccountTable");
+      }
+    }
+
+    @Nested class when_the_migration_is_repeatable {
+      @Test void returns_the_name_of_the_migrations_including_the_version_prefix() {
+        final var migration = new R001TestSeed();
+
+        assertThat(migration.getDescription()).isEqualTo("001TestSeed");
+      }
     }
   }
 


### PR DESCRIPTION
Flyway uses the description to determine the order of execution of repeatable migrations. Adding the version to the migration description allows users to easily control the order of execution of repeatable migrations.